### PR TITLE
Make setting/getting stateless incidents more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ Incident(pk=8, start_time=datetime.datetime(2021, 4, 22, 11, 41, 53, 580947, tzi
 
 ```
 
+### Stateless incidents
+
+Argus supports a concept of "stateless" incidents. Stateless incidents
+represent single points in time, and do not have an end time. To explicitly
+create stateless incidents, set the `end_time` attribute to the STATELESS
+sentinel, like so:
+
+```python
+from datetime import datetime
+from pyargus.models import Incident, STATELESS
+
+stateless_incident = Incident(
+    description="Something happened",
+    start_time=datetime.now(),
+    end_time=STATELESS
+)
+```
+
 ## BUGS
 
 * Doesn't provide high-level error handling yet.

--- a/src/pyargus/models.py
+++ b/src/pyargus/models.py
@@ -59,7 +59,7 @@ class Incident:
                 if kwargs["end_time"] != "infinity"
                 else datetime.max
             )
-        elif "end_time" in kwargs:
+        else:
             kwargs["end_time"] = STATELESS
         kwargs["source"] = SourceSystem.from_json(kwargs["source"])
 


### PR DESCRIPTION
The upstream API interprets a `null`/`None` value in an incident's `end_time` field as an indication of a stateless incident.

However, `None` values in this library's data classes usually indicates that a value *is not set*, or *should not be set* when posting to the API. 

The upstream API changed what `end_time` defaults to if omitted when posting, leading to an attempted fix in this library in a200ed36881b6875b4fea0f628c6e3270b741e2c - however, the fix also caused incident update operations to become impossible: The fix would always post a value for `end_time` during an update (posting `None` if no value was set), due to the way `Incident` objects are serialized to JSON. However, the upstream does not allow for direct modification of `end_time` attributes on existing records, causing all updates to fail.

This PR introduces an explicit sentinel `STATELESS` to assign to `end_time` when a client wishes to explicitly create stateless incidents.

Fixes #4.
Fixes #3.

