### PR TITLE
Ignore unknown attributes of fetched incidents

### DIFF
--- a/src/pyargus/models.py
+++ b/src/pyargus/models.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from iso8601 import parse_date
+import inspect
+
 
 # STATELESS is a sentinel used as an `end_time` value to explicitly indicate that an
 # incident is in fact stateless. To the Argus API, this is represented by a null/None
@@ -67,7 +69,13 @@ class Incident:
         tags = dict(tag.split("=", maxsplit=1) for tag in tags)
         kwargs["tags"] = tags
 
-        return cls(**kwargs)
+        return cls(
+            **{
+                key: value
+                for key, value in kwargs.items()
+                if key in inspect.signature(cls).parameters
+            }
+        )
 
     def to_json(self) -> dict:
         """Despite the name, this serializes this object into a dict that is suitable

--- a/src/pyargus/models.py
+++ b/src/pyargus/models.py
@@ -48,6 +48,7 @@ class Incident:
     stateful: bool = None
     open: bool = None
     acked: bool = None
+    metadata: dict = None
 
     @classmethod
     def from_json(cls, data: dict) -> Incident:


### PR DESCRIPTION
Closes #6. Also adds metadata to `Incident` model, it does not break with API v1, I have tested it. 

The result of fetching v1 looks like this
```
Incident(pk=15, start_time=datetime.datetime(2024, 6, 19, 11, 33, 54, 
tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), 
end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), 
source=SourceSystem(pk=1, name='argus', type='argus', user=1, base_url=''), 
source_incident_id='2931083646', details_url='', 
description='Incident #2931083646 created via "create_fake_incident"', 
level=4, ticket_url='https://gitlab.sikt.no/joheng/testing/-/issues/44', 
tags={'location': 'argus', 'object': '15', 'problem_type': 'test'}, 
stateful=True, open=True, acked=False, 
metadata=None)
```

and v2 like this 
```
Incident(pk=15, start_time=datetime.datetime(2024, 6, 19, 11, 33, 54, 
tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), 
end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), 
source=SourceSystem(pk=1, name='argus', type='argus', user=1, base_url=''), 
source_incident_id='2931083646', details_url='', 
description='Incident #2931083646 created via "create_fake_incident"',
level=4, ticket_url='https://gitlab.sikt.no/joheng/testing/-/issues/44', 
tags={'location': 'argus', 'object': '15', 'problem_type': 'test'}, 
stateful=True, open=True, acked=False, 
metadata={'a': 'b', 'c': 'd', 'additional_dict': {'e': 'f'}})
```