### PR TITLE
Set up integration testing using an Argus server running in Docker Compose

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-docker-compose-v2==0.1.1",
+    "requests",
+]
 dev = [
     "build",
     "coverage",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import pytest
+import requests
+from urllib.parse import urljoin
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+
+TEST_PASSWORD = "fakef00bar"
+
+pytest_plugins = ["docker_compose"]
+
+
+@pytest.fixture(scope="session")
+def argus_api(wait_for_argus_api):
+    """Returns the URL and a valid token for a running Argus API server"""
+
+    request_session, container = wait_for_argus_api
+    container.execute(["django-admin", "initial_setup"])
+    container.execute(["django-admin", "setpassword", "admin", TEST_PASSWORD])
+
+    service = container.network_info[0]
+    argus_url = f"http://127.0.0.1:{service.host_port}/"
+
+    response = request_session.post(
+        urljoin(argus_url, "/api/v1/token-auth/"),
+        data={"username": "admin", "password": TEST_PASSWORD},
+    )
+    token = response.json().get("token", None)
+    assert token, f"Failed to get token from {response.payload}"
+
+    return "http://localhost:8000/api/v2", token
+
+
+@pytest.fixture(scope="session")
+def wait_for_argus_api(session_scoped_container_getter):
+    """Wait for an Argus API server to become responsive.
+
+    :returns: A tuple of the request session used to test for connectivity and an
+    object representing the API container instance
+    """
+    request_session = requests.Session()
+    retries = Retry(total=5, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504])
+    request_session.mount("http://", HTTPAdapter(max_retries=retries))
+
+    container = session_scoped_container_getter.get("argus_api")
+    service = container.network_info[0]
+    argus_url = f"http://127.0.0.1:{service.host_port}/"
+    print(f"Attempting to connect to {argus_url}")
+    assert request_session.get(argus_url)
+    return request_session, container

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/uninett/argus:1.29.0
+
+RUN mkdir -p /extrapython
+COPY ci_settings.py /extrapython/ci_settings.py
+ENV PYTHONPATH=/extrapython
+ENV DJANGO_SETTINGS_MODULE=ci_settings

--- a/tests/docker/ci_settings.py
+++ b/tests/docker/ci_settings.py
@@ -1,0 +1,7 @@
+"""Site settings for running argus server in an integration test harness"""
+
+from argus.site.settings.backend import *
+
+# Allow all hosts, since all requests will typically come from outside the container
+ALLOWED_HOSTS = ["*"]
+DEBUG = True

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+# Defines an Argus backend to use for integration testing
+services:
+  argus_api:
+    build: .
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      - SECRET_KEY=xahQuuWaip1Ookeegaibo6yoj5ij8shok8Eg7eiyeBoo9AaQu5b
+      - TIME_ZONE=Europe/Oslo
+      - DATABASE_URL=postgresql://argus:argus@postgres/argus
+      - ARGUS_REDIS_SERVER=redis
+      - ARGUS_FRONTEND_URL=http://localhost:3000  # fake it till you make it  #maybe not need this
+      - ARGUS_COOKIE_DOMAIN=localhost   # maybe not need this
+      - STATIC_ROOT=static/
+      - ARGUS_SEND_NOTIFICATIONS=0
+      - EMAIL_HOST=localhost
+      - DEFAULT_FROM_EMAIL=ci-test@example.org
+    restart: always
+
+  postgres:
+    image: "postgres:14"
+    environment:
+      - POSTGRES_USER=argus
+      - POSTGRES_PASSWORD=argus
+      - POSTGRES_DB=argus
+    restart: always
+
+  redis:
+    image: "redis:latest"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterable
+from datetime import datetime
+
+import pytest
+
+from pyargus.client import Client
+from pyargus.models import Incident
+
+
+class TestApiIntegration:
+    def test_incidents_list_should_return_iterable(self, api_client):
+        incidents = api_client.get_incidents()
+        assert isinstance(incidents, Iterable)
+
+    @pytest.mark.xfail(
+        reason="We must add a source system to Argus to do this properly"
+    )
+    def test_when_posting_incident_it_should_return_full_incident(self, api_client):
+        post = Incident(
+            description="The earth was demolished to make way for a hyperspace bypass",
+            start_time=datetime.now(),
+            tags={
+                "host": "earth.example.org",
+            },
+        )
+        result = api_client.post_incident(post)
+        assert isinstance(result, Incident)
+        assert result.description == post.description
+        assert result.pk
+
+
+@pytest.fixture
+def api_client(argus_api):
+    url, token = argus_api
+    return Client(url, token)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}
+envlist = py{39,310,311}
 basepython = python3.9
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,4 @@ commands =
 
 [pytest]
 addopts = --docker-compose=tests/docker/docker-compose.yml
+testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,7 @@ python =
 
 [testenv]
 deps =
-    pytest
-    -r requirements.txt
+  .[test]
 setenv =
     PYTHONPATH = {toxinidir}/tests:{toxinidir}/src
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,6 @@ setenv =
 usedevelop = True
 commands =
     pytest tests
+
+[pytest]
+addopts = --docker-compose=tests/docker/docker-compose.yml


### PR DESCRIPTION
This sets up pytest fixtures to start a full Argus server (using docker-compose) that can be used for full integration tests of the API library.  This will enable us to properly verify the validity of this library against Argus.