### PR TITLE
Remove superfluous config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
     -   id: ruff
         name: "Ruff linting"
         args: [
-          '--output-format=full',
           '--statistics'
         ]
         # Run the formatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,3 @@ extend-exclude = [
     ".egg-info",
 ]
 output-format = "full"
-
-[tool.ruff.lint]
-select = ["E4", "E7", "E9", "F4", "F5", "F6", "F7", "F8", "F9"]
-ignore = ["F403", "F405"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,4 +44,3 @@ line-length = 88
 extend-exclude = [
     ".egg-info",
 ]
-output-format = "full"


### PR DESCRIPTION
We don't need to ignore the same rules as in Argus since pyargus does not break these rules. The selected rules are also the default rules so that config part can also be removed. And `output-format` is `full` by default.