### PR TITLE
Remove py38 test environment from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,313}
+envlist = py{39,310,311,312,313}
 basepython = python3.9
 
 [gh-actions]


### PR DESCRIPTION
b9457b2b598ee7ef32426485f1b097dbf6c3c8f0 dropped support for Python 3.8, so there is no point in keeping it around in the default tox environment list.