### PR TITLE
Modernize `pyproject.toml` with build-system and dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "argus-api-client"
 dynamic = ["version"]
@@ -20,17 +24,22 @@ dependencies = [
     "iso8601",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-argus-server>=0.2.0",
+]
 dev = [
     "build",
     "coverage",
     "ipython",
     "isort",
     "pre-commit",
-    "pytest",
     "ruff",
     "tox",
     "twine",
+    {include-group = "test"},
 ]
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-simple_rest_client==1.0.8
-iso8601==0.1.13

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-cov
-pytest-argus-server>=0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,8 @@ python =
     3.13: py313
 
 [testenv]
-deps =
-    -r requirements.txt
-    -r tests/requirements.txt
+dependency_groups =
+    test
 setenv =
     PYTHONPATH = {toxinidir}/tests:{toxinidir}/src
 package = editable


### PR DESCRIPTION
## Scope and purpose

Modernize the project configuration to use current Python packaging standards.

### This pull request
* adds/changes/removes a dependency

## Changes

- Add explicit `[build-system]` table so that tools like `uv` can build and install the package as editable
- Migrate dev/test dependencies from `requirements.txt` and `tests/requirements.txt` to PEP 735 `[dependency-groups]` in `pyproject.toml`
- Update `tox.ini` to reference the `test` dependency group instead of requirements files
- Delete the now-redundant requirements files

## Contributor Checklist

* [ ] ~~Added/amended tests for new/changed code~~
* [x] Linted/formatted the code with ruff, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long