### PR TITLE
Add ruff lint rules for import sorting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Fix trailing whitespace @johannaengland 04/02/2025
 fd26a5a7084e848ae24cd3e24e67378dc66cb9e6
+
+# Reformat imports with ruff import sorting rules @lunkwill42 15/04/2026
+b6b09c11eaf84da798f2c64f1cc7301d55040d9b

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
         # Run the linter
     -   id: ruff
         name: "Ruff linting"
+        files: ^(src|tests)/
         # Run the formatter
     -   id: ruff-format
         name: "Ruff formatting"
+        files: ^(src|tests)/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     "build",
     "coverage",
     "ipython",
-    "isort",
     "pre-commit",
     "ruff",
     "tox",
@@ -54,3 +53,7 @@ line-length = 88
 extend-exclude = [
     ".egg-info",
 ]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+fixable = ["I"]

--- a/src/pyargus/client.py
+++ b/src/pyargus/client.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, TypeVar, Iterator, Callable, Tuple
-from urllib.parse import urlparse, parse_qs
+from typing import Callable, Iterator, List, Tuple, TypeVar
+from urllib.parse import parse_qs, urlparse
 
 from simple_rest_client.models import Response
 
-from . import api
-from . import models
+from . import api, models
 
 __all__ = ["Client"]
 

--- a/src/pyargus/models.py
+++ b/src/pyargus/models.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
+import inspect
 from dataclasses import dataclass
 from datetime import datetime
+
 from iso8601 import parse_date
-import inspect
 
 
 # STATELESS is a sentinel used as an `end_time` value to explicitly indicate that an

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyargus import api
 
 


### PR DESCRIPTION
## Scope and purpose

Depends on #44.

Enable ruff's isort-compatible import sorting (`I` rule) alongside the default error rules, matching the configuration used in zino-argus-glue and NAV.

### This pull request
* adds/changes/removes a dependency

## Changes

- Add `[tool.ruff.lint]` section with `select = ["E4", "E7", "E9", "F", "I"]` and `fixable = ["I"]`
- Remove redundant `isort` dev dependency (ruff handles it now)
- Scope ruff pre-commit hooks to `src/` and `tests/` directories only
- Reformat existing imports to comply with new rules
- Update `.git-blame-ignore-revs` with the reformatting commit

## Contributor Checklist

* [ ] ~~Added/amended tests for new/changed code~~
* [x] Linted/formatted the code with ruff, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long