### PR TITLE
Add async client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ c = Client(api_root_url="https://argus.example.org/api/v2", token=tokenobj.token
 # secrets file so that it is not lost on program exit
 ```
 
+## Async usage
+
+An `AsyncClient` is available for use in asyncio-based applications. It mirrors
+the `Client` interface, but all methods are coroutines. Use `python -m asyncio`
+to try these examples interactively:
+
+```pycon
+>>> from pyargus.async_client import AsyncClient
+>>> from pyargus.models import Incident
+>>> from datetime import datetime
+>>> c = AsyncClient(api_root_url="https://argus.example.org/api/v2", token="foobar")
+>>> async for incident in c.get_incidents(open=True, acked=False):
+...    print(incident)
+...
+Incident(pk=4, ...)
+>>> i = Incident(
+...     description="The earth was demolished to make way for a hyperspace bypass",
+...     start_time=datetime.now(),
+...     tags={"host": "earth.example.org"},
+... )
+>>> await c.post_incident(i)
+Incident(pk=8, ...)
+```
+
 ## BUGS
 
 * Doesn't provide high-level error handling yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [dependency-groups]
 test = [
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-argus-server>=0.2.0",
 ]

--- a/src/pyargus/__init__.py
+++ b/src/pyargus/__init__.py
@@ -1,3 +1,6 @@
 """Argus API client library"""
 
+from pyargus.async_client import AsyncClient as AsyncClient
+from pyargus.client import Client as Client
+
 VERSION = "0.6.0"

--- a/src/pyargus/async_api.py
+++ b/src/pyargus/async_api.py
@@ -1,0 +1,56 @@
+"""Defines an async low-level API interface for Argus using simple_rest_client"""
+
+from simple_rest_client.api import API
+from simple_rest_client.resource import AsyncResource
+
+from .api import (
+    ExpiringTokenResource,
+    IncidentAcknowledgementResource,
+    IncidentEventResource,
+    IncidentResource,
+)
+
+
+def async_connect(api_root_url: str, token: str, timeout: float = 2.0) -> API:
+    """Connects to an Argus API instance using async resources.
+
+    :returns: A connected simple_rest_client API object with async resources
+    """
+    headers = {"Authorization": "Token " + token}
+    argusapi = API(
+        api_root_url=api_root_url,
+        headers=headers,
+        timeout=timeout,
+        json_encode_body=True,
+        append_slash=True,
+    )
+    argusapi.add_resource(
+        resource_name="incidents", resource_class=AsyncIncidentResource
+    )
+    argusapi.add_resource(
+        resource_name="events", resource_class=AsyncIncidentEventResource
+    )
+    argusapi.add_resource(
+        resource_name="acknowledgements",
+        resource_class=AsyncIncidentAcknowledgementResource,
+    )
+    argusapi.add_resource(
+        resource_name="tokens", resource_class=AsyncExpiringTokenResource
+    )
+    return argusapi
+
+
+class AsyncIncidentResource(AsyncResource):
+    actions = IncidentResource.actions
+
+
+class AsyncIncidentEventResource(AsyncResource):
+    actions = IncidentEventResource.actions
+
+
+class AsyncIncidentAcknowledgementResource(AsyncResource):
+    actions = IncidentAcknowledgementResource.actions
+
+
+class AsyncExpiringTokenResource(AsyncResource):
+    actions = ExpiringTokenResource.actions

--- a/src/pyargus/async_client.py
+++ b/src/pyargus/async_client.py
@@ -1,0 +1,172 @@
+"""Async version of the higher level Argus API client abstraction"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import AsyncIterator, Callable, List, Tuple
+
+from . import async_api, models
+from .client import IncidentType, extract_params, has_next_page, is_paginated_response
+
+__all__ = ["AsyncClient"]
+
+
+class AsyncClient:
+    """Async high-level Argus API client.
+
+    The low-level simple_rest_client API is available in the `api` instance variable.
+    """
+
+    def __init__(self, api_root_url: str, token: str, timeout: float = 2.0):
+        self.api = async_api.async_connect(api_root_url, token, timeout)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} {self.api.api_root_url!r}>"
+
+    async def get_incident(self, incident_id: int) -> models.Incident:
+        """Retrieves an incident based on its Argus ID"""
+        response = await self.api.incidents.retrieve(incident_id)
+        return models.Incident.from_json(response.body)
+
+    async def get_incidents(self, **filters) -> AsyncIterator[models.Incident]:
+        """Retrieves Argus Incidents as an async generator.
+
+        Use keyword arguments for filtering, unless you want every last bit from the
+        API.
+
+        Usage example:
+        >>> [i async for i in client.get_incidents(open=True, acked=False)]
+        [Incident(...), ...]
+        """
+        async for response, results in async_paginated_query(
+            self.api.incidents.list, params=filters
+        ):
+            for record in results:
+                yield models.Incident.from_json(record)
+
+    async def get_my_incidents(self, **filters) -> AsyncIterator[models.Incident]:
+        """Retrieves all Incidents that came from the Source System represented by
+        this client, returning them as an async generator.
+
+        Use keyword arguments for filtering, unless you want every last bit from the
+        API.
+
+        Usage example:
+        >>> [i async for i in client.get_my_incidents(open=True, acked=False)]
+        [Incident(...), ...]
+        """
+        async for response, results in async_paginated_query(
+            self.api.incidents.list_mine, params=filters
+        ):
+            for record in results:
+                yield models.Incident.from_json(record)
+
+    async def get_incident_events(self, incident: IncidentType) -> List[models.Event]:
+        """Returns a list of all events related to an Incident"""
+        pk = incident.pk if isinstance(incident, models.Incident) else int(incident)
+        response = await self.api.events.list(pk)
+        return [models.Event.from_json(record) for record in response.body]
+
+    async def get_incident_acknowledgements(
+        self, incident: IncidentType
+    ) -> List[models.Acknowledgement]:
+        """Returns a list of all acknowledgements on an Incident"""
+        pk = incident.pk if isinstance(incident, models.Incident) else int(incident)
+        response = await self.api.acknowledgements.list(pk)
+        return [models.Acknowledgement.from_json(record) for record in response.body]
+
+    async def post_incident(self, incident: models.Incident) -> models.Incident:
+        """Posts a new Incident to Argus.
+
+        :returns: A full Incident description as returned from the API.
+        """
+        body = incident.to_json()
+        response = await self.api.incidents.create(body=body)
+        return models.Incident.from_json(response.body)
+
+    async def update_incident(self, incident: models.Incident) -> models.Incident:
+        """Updates an Argus Incident.
+
+        :returns: A full Incident description as returned from the API.
+        """
+        pk = incident.pk
+        body = incident.to_json()
+        # The API takes the primary key as part of the URL, not as part of the body
+        if "pk" in body:
+            del body["pk"]
+        response = await self.api.incidents.update(pk, body=body)
+        return models.Incident.from_json(response.body)
+
+    async def resolve_incident(
+        self,
+        incident: IncidentType,
+        description: str = None,
+        timestamp: datetime = None,
+    ) -> models.Event:
+        """Resolves an Argus Incident
+
+        :param description: An optional event description to post.
+        :param timestamp: When the event happened. Defaults to the current datetime.
+        :returns: A full Event description as returned from the API.
+        """
+        if timestamp is None:
+            timestamp = datetime.now()
+        end_event = models.Event(
+            description=description, timestamp=timestamp, type="END"
+        )
+        return await self.post_incident_event(incident, end_event)
+
+    async def post_incident_event(
+        self, incident: IncidentType, event: models.Event
+    ) -> models.Event:
+        """Posts a new Incident Event to Argus
+
+        :returns: A full Event description as returned from the API.
+        """
+        incident_pk = incident if isinstance(incident, int) else incident.pk
+        body = event.to_json()
+        response = await self.api.events.create(incident_pk, body=body)
+        return models.Event.from_json(response.body)
+
+    async def refresh_token(self) -> models.ExpiringToken:
+        """Post w/o body to get a new token and its expiration timestamp
+
+        It will be necessary to re-initialize the client as the old token has
+        been rendered invalid.
+
+        Store the new token (and the returned expiration datetime) where your
+        program can load it on next run: environment variable, config file or
+        secrets file.
+        """
+        response = await self.api.tokens.refresh()
+        return models.ExpiringToken.from_json(response.body)
+
+
+async def async_paginated_query(
+    method: Callable, *args, **kwargs
+) -> AsyncIterator[Tuple]:
+    """Extracts paginated results from an async simple_rest_client API call.
+
+    This function is an async generator that produces subsequent results for each page
+    retrieved. Non-paginated results are also supported. Each generated value is a
+    two-tuple of the form `(response, results)`, where `response` is the
+    simple_rest_client response object and `results` is the list of results extracted
+    from the response body.
+
+    :type method: An async API instance method to call
+    :type args: Arguments to pass to method
+    :type kwargs: Keyword arguments to pass to method
+
+    """
+    response = await method(*args, **kwargs)
+    if is_paginated_response(response):
+        yield response, response.body["results"]
+
+        while has_next_page(response):
+            next_url = response.body["next"]
+            kwargs["params"] = extract_params(next_url)
+            response = await method(*args, **kwargs)
+            yield response, response.body["results"]
+
+    else:
+        yield response, response.body

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -1,0 +1,17 @@
+"""Tests for async API module"""
+
+import pytest
+
+from pyargus import async_api
+
+
+def test_async_connect_should_return_api_client():
+    client = async_api.async_connect("random", "token")
+    assert client
+
+
+@pytest.mark.asyncio
+async def test_async_api_client_with_bad_args_should_fail():
+    client = async_api.async_connect("random", "token")
+    with pytest.raises(Exception):
+        await client.incidents.list_open_unacked()

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,35 @@
+from collections.abc import AsyncIterable
+from datetime import datetime
+
+import pytest
+
+from pyargus.async_client import AsyncClient
+from pyargus.models import Incident
+
+
+class TestAsyncApiIntegration:
+    @pytest.mark.asyncio
+    async def test_incidents_list_should_return_async_iterable(self, async_api_client):
+        incidents = async_api_client.get_incidents()
+        assert isinstance(incidents, AsyncIterable)
+
+    @pytest.mark.asyncio
+    async def test_when_posting_incident_it_should_return_full_incident(
+        self, async_api_client
+    ):
+        post = Incident(
+            description="The earth was demolished to make way for a hyperspace bypass",
+            start_time=datetime.now(),
+            tags={
+                "host": "earth.example.org",
+            },
+        )
+        result = await async_api_client.post_incident(post)
+        assert isinstance(result, Incident)
+        assert result.description == post.description
+        assert result.pk
+
+
+@pytest.fixture
+def async_api_client(argus_api_url, argus_source_system_token):
+    return AsyncClient(argus_api_url, argus_source_system_token)


### PR DESCRIPTION
## Scope and purpose

Add asyncio support to pyargus, enabling use in async applications such as the upcoming zabbix-argus-glue service.

Adding a parallel async interface was straightforward thanks to `simple_rest_client`'s existing `AsyncResource` class, which uses `httpx.AsyncClient` under the hood. The async resource classes simply reuse the `actions` dicts from their sync counterparts, and `AsyncClient` mirrors the sync `Client` interface with `async def`/`await`.

Test coverage could probably better, but it should be on par with existing coverage of the synchronous version of the client.

### This pull request
* adds a new feature

## Changes

- Add `AsyncClient` class mirroring the sync `Client` interface — all methods are coroutines, paginated queries are async generators
- Add async API resource classes leveraging `simple_rest_client`'s existing `AsyncResource`
- Export both `Client` and `AsyncClient` from the package root
- Add `pytest-asyncio` to test dependency group
- Add async usage examples to README

## Contributor Checklist

* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long