### PR TITLE
Mark unused pagination response var with underscore

### DIFF
--- a/src/pyargus/async_client.py
+++ b/src/pyargus/async_client.py
@@ -38,7 +38,7 @@ class AsyncClient:
         >>> [i async for i in client.get_incidents(open=True, acked=False)]
         [Incident(...), ...]
         """
-        async for response, results in async_paginated_query(
+        async for _response, results in async_paginated_query(
             self.api.incidents.list, params=filters
         ):
             for record in results:
@@ -55,7 +55,7 @@ class AsyncClient:
         >>> [i async for i in client.get_my_incidents(open=True, acked=False)]
         [Incident(...), ...]
         """
-        async for response, results in async_paginated_query(
+        async for _response, results in async_paginated_query(
             self.api.incidents.list_mine, params=filters
         ):
             for record in results:

--- a/src/pyargus/client.py
+++ b/src/pyargus/client.py
@@ -43,7 +43,7 @@ class Client:
         >>> list(client.get_incidents(open=True, acked=False))
         [Incident(...), ...]
         """
-        for response, results in paginated_query(
+        for _response, results in paginated_query(
             self.api.incidents.list, params=filters
         ):
             for record in results:
@@ -60,7 +60,7 @@ class Client:
         >>> list(client.get_my_incidents(open=True, acked=False))
         [Incident(...), ...]
         """
-        for response, results in paginated_query(
+        for _response, results in paginated_query(
             self.api.incidents.list_mine, params=filters
         ):
             for record in results:


### PR DESCRIPTION
## Scope and purpose

Address a review nit from #46: the first element of the tuple yielded by `paginated_query` (and its async counterpart) is never used by the client methods that iterate over it. Prefix it with an underscore to make this explicit and silence linter nits.

### This pull request
* is a minor cleanup

## Changes

- Rename `response` to `_response` in the pagination loops in `client.py` and `async_client.py`

## Contributor Checklist

* [x] Linted/formatted the code with ruff, easiest by using pre-commit
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long