### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a report to help us improve pyargus
+title: ''
+labels: ''
+type: Bug
+assignees: ''
+
+---
+
+### Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+### Code to reproduce
+
+<!--
+A minimal code snippet that triggers the bug:
+
+```python
+from pyargus.client import Client
+...
+```
+-->
+
+### Expected behaviour
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Actual behaviour
+
+<!-- What happened instead. If an exception was raised, include the full
+traceback inside a `pytb` code block:
+
+```pytb
+Paste Python traceback here...
+```
+-->
+
+### Environment
+
+<!--
+ - pyargus version [e.g. 0.7.0] (`pip show argus-api-client`)
+ - Python version [e.g. 3.11.2] (run `python3 --version`)
+ - Argus server version, if known
+-->
+
+### Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Scope and purpose
+
+Fixes #<!-- ISSUE-ID -->. <!-- Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
+
+<!-- Add a description of what this PR does and why it is needed. If a linked
+ticket fully covers it, you can omit this. -->
+
+<!-- remove things that do not apply -->
+### This pull request
+* adds/changes/removes a dependency
+* changes the library's public API <!-- pyargus follows SemVer; call out any backwards-incompatible change -->
+
+## Contributor Checklist
+
+<!-- Add an "X" inside the brackets to confirm -->
+<!-- Remove checks that do not apply; if you leave one unchecked, explain why below it -->
+
+* [ ] Added an entry to `CHANGELOG.md`
+* [ ] Added/amended tests for new/changed code
+* [ ] Linted/formatted the code with ruff, easiest by using [pre-commit](https://pre-commit.com/)
+* [ ] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Scope and purpose
 
-Fixes #<!-- ISSUE-ID -->. <!-- Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
+Fixes #<!-- ISSUE-ID -->. Dependent on #<!-- PR-ID -->. <!-- Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
 
 <!-- Add a description of what this PR does and why it is needed. If a linked
 ticket fully covers it, you can omit this. -->


### PR DESCRIPTION
The repository has no issue or pull request templates, so contributions arrive free-form and may miss the details a reviewer needs. This adds two templates under `.github/` to prompt for that information up front.

Both are tailored to pyargus as a *library*, and to this repo's actual conventions rather than copied wholesale from the sibling Argus-ecosystem projects:

- The [bug report template](https://github.com/Uninett/pyargus/blob/757c5f02e37eea23b614346f970d49cd1cdbe2d1/.github/ISSUE_TEMPLATE/bug_report.md) asks for a minimal code snippet and a traceback rather than the GUI-oriented "steps / screenshots / browser" fields used by front-facing applications, and sets the native GitHub Issue Type via `type: Bug`.
- The [pull request template](https://github.com/Uninett/pyargus/blob/757c5f02e37eea23b614346f970d49cd1cdbe2d1/.github/pull_request_template.md) points its changelog checklist item at the manually-maintained `CHANGELOG.md` (Keep a Changelog), since pyargus does not use towncrier the way `Uninett/Argus` and `Uninett/nav` do, and drops the docs/database/UI items that don't apply to a client library.

I filed #52 free-form for want of the bug report template.
