### PR TITLE
Preserve multi-valued incident tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Incident tags with repeated keys are no longer silently collapsed.
+  `Incident.tags` is now a `MultiValueDict` that preserves every value per
+  key, both when reading incidents from Argus and when posting them
+  (fixes #52).
+
 ## [0.7.0] - 2026-04-30
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ implemented in `pyargus.models`.
 >>> for incident in c.get_incidents(open=True, acked=False):
 ...    print(incident)
 ...
-Incident(pk=4, start_time=datetime.datetime(2021, 4, 4, 16, 37, 43, 293726, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='202430', details_url='http://localhost/search/event/202430', description='uninett-gsw2 BGP session with 158.38.3.112 is DOWN', level=5, ticket_url='', tags={'location': 'Teknobyen Innovasjonssenter', 'kundetjeneste': 'Nett_CNaaS', 'kunde': 'example.org', 'event_type': 'bgpState', 'alert_type': 'bgpDown', 'room': '100', 'organization': 'uninett.srv', 'host': 'uninett-gsw2.uninett.no'}, stateful=True, open=True, acked=False)
-Incident(pk=3, start_time=datetime.datetime(2021, 4, 4, 16, 32, 53, 128780, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='202429', details_url='http://localhost/search/event/202429', description='uninett-gsw1 BGP session with 158.38.3.112 is DOWN', level=5, ticket_url='', tags={'location': 'Teknobyen Innovasjonssenter', 'kundetjeneste': 'Nett_CNaaS', 'kunde': 'example.org', 'event_type': 'bgpState', 'alert_type': 'bgpDown', 'host': 'uninett-gsw1.uninett.no', 'room': '100', 'organization': 'uninett.srv'}, stateful=True, open=True, acked=False)
-Incident(pk=2, start_time=datetime.datetime(2017, 8, 31, 14, 58, 31, 118794, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='184296', details_url='http://localhost/search/event/184296', description='Link DOWN on Gi0/3 at oldsmobile.lab (Simple is better than complex)', level=5, ticket_url='', tags={'room': '113', 'location': 'Teknobyen Innovasjonssenter', 'organization': 'uninett.testlab', 'kundetjeneste': 'Nett_CNaaS', 'kunde': 'example.org', 'event_type': 'linkState', 'alert_type': 'linkDown', 'host': 'oldsmobile.lab.uninett.no', 'interface': 'Gi0/3'}, stateful=True, open=True, acked=False)
+Incident(pk=4, start_time=datetime.datetime(2021, 4, 4, 16, 37, 43, 293726, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='202430', details_url='http://localhost/search/event/202430', description='uninett-gsw2 BGP session with 158.38.3.112 is DOWN', level=5, ticket_url='', tags=MultiValueDict([('location', 'Teknobyen Innovasjonssenter'), ('kundetjeneste', 'Nett_CNaaS'), ('kunde', 'example.org'), ('event_type', 'bgpState'), ('alert_type', 'bgpDown'), ('room', '100'), ('organization', 'uninett.srv'), ('host', 'uninett-gsw2.uninett.no')]), stateful=True, open=True, acked=False)
+Incident(pk=3, start_time=datetime.datetime(2021, 4, 4, 16, 32, 53, 128780, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='202429', details_url='http://localhost/search/event/202429', description='uninett-gsw1 BGP session with 158.38.3.112 is DOWN', level=5, ticket_url='', tags=MultiValueDict([('location', 'Teknobyen Innovasjonssenter'), ('kundetjeneste', 'Nett_CNaaS'), ('kunde', 'example.org'), ('event_type', 'bgpState'), ('alert_type', 'bgpDown'), ('host', 'uninett-gsw1.uninett.no'), ('room', '100'), ('organization', 'uninett.srv')]), stateful=True, open=True, acked=False)
+Incident(pk=2, start_time=datetime.datetime(2017, 8, 31, 14, 58, 31, 118794, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='184296', details_url='http://localhost/search/event/184296', description='Link DOWN on Gi0/3 at oldsmobile.lab (Simple is better than complex)', level=5, ticket_url='', tags=MultiValueDict([('room', '113'), ('location', 'Teknobyen Innovasjonssenter'), ('organization', 'uninett.testlab'), ('kundetjeneste', 'Nett_CNaaS'), ('kunde', 'example.org'), ('event_type', 'linkState'), ('alert_type', 'linkDown'), ('host', 'oldsmobile.lab.uninett.no'), ('interface', 'Gi0/3')]), stateful=True, open=True, acked=False)
 ```
 
 As you can see, the arguments given to `get_incidents()` are translated
@@ -54,7 +54,7 @@ Example:
 >>> for incident in c.get_my_incidents(open=True, acked=False):
 ...    print(incident)
 ...
-Incident(pk=3, start_time=datetime.datetime(2021, 4, 4, 16, 32, 53, 128780, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=3, name='foobar, type='nav', user=4, base_url='http://localhost/'), source_incident_id='2716057', details_url='http://localhost/search/event/2716057', description='uninett-gsw1 BGP session with 158.38.3.112 is DOWN', level=5, ticket_url='', tags={'location': 'Teknobyen Innovasjonssenter', 'kundetjeneste': 'Nett_CNaaS', 'kunde': 'example.org', 'event_type': 'bgpState', 'alert_type': 'bgpDown', 'host': 'uninett-gsw1.uninett.no', 'room': '100', 'organization': 'uninett.srv'}, stateful=True, open=True, acked=False)
+Incident(pk=3, start_time=datetime.datetime(2021, 4, 4, 16, 32, 53, 128780, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=datetime.datetime(9999, 12, 31, 23, 59, 59, 999999), source=SourceSystem(pk=3, name='foobar, type='nav', user=4, base_url='http://localhost/'), source_incident_id='2716057', details_url='http://localhost/search/event/2716057', description='uninett-gsw1 BGP session with 158.38.3.112 is DOWN', level=5, ticket_url='', tags=MultiValueDict([('location', 'Teknobyen Innovasjonssenter'), ('kundetjeneste', 'Nett_CNaaS'), ('kunde', 'example.org'), ('event_type', 'bgpState'), ('alert_type', 'bgpDown'), ('host', 'uninett-gsw1.uninett.no'), ('room', '100'), ('organization', 'uninett.srv')]), stateful=True, open=True, acked=False)
 ```
 
 ### Post a new incident
@@ -72,7 +72,7 @@ Incident(pk=3, start_time=datetime.datetime(2021, 4, 4, 16, 32, 53, 128780, tzin
 ...     }
 ... )
 >>> c.post_incident(i)
-Incident(pk=8, start_time=datetime.datetime(2021, 4, 22, 11, 41, 53, 580947, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=None, source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='', details_url='', description='The earth was demolished to make way for a hyperspace bypass', level=5, ticket_url='', tags={'host': 'earth.example.org'}, stateful=False, open=False, acked=False)
+Incident(pk=8, start_time=datetime.datetime(2021, 4, 22, 11, 41, 53, 580947, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=None, source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='', details_url='', description='The earth was demolished to make way for a hyperspace bypass', level=5, ticket_url='', tags=MultiValueDict([('host', 'earth.example.org')]), stateful=False, open=False, acked=False)
 ```
 
 The `post_incident()` method returns the full `Incident` record, as stored in
@@ -113,9 +113,47 @@ wish you modify, and then adding values to the attributes you wish to modify:
 ...     }
 ... )
 >>> c.update_incident(i)
-Incident(pk=8, start_time=datetime.datetime(2021, 4, 22, 11, 41, 53, 580947, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=None, source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='', details_url='', description='The earth was demolished to make way for a hyperspace bypass', level=None, ticket_url='', tags={'host': 'earth.example.org', 'location': 'Milky way'}, stateful=False, open=False, acked=False)
+Incident(pk=8, start_time=datetime.datetime(2021, 4, 22, 11, 41, 53, 580947, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200), '+02:00')), end_time=None, source=SourceSystem(pk=2, name='testnav', type='nav', user=3, base_url='http://localhost/'), source_incident_id='', details_url='', description='The earth was demolished to make way for a hyperspace bypass', level=None, ticket_url='', tags=MultiValueDict([('host', 'earth.example.org'), ('location', 'Milky way')]), stateful=False, open=False, acked=False)
 
 ```
+
+### Working with multi-valued tags
+
+Argus allows an incident to carry the same tag key more than once (for example
+two different `host` values). The `tags` attribute is therefore a
+`MultiValueDict` — a `dict` subclass that keeps every value while still behaving
+like an ordinary dictionary for code that expects a single value per key.
+
+Construct it from a sequence of `(key, value)` pairs (unlike a plain `dict`,
+repeated keys are kept), or build it up with `add()`:
+
+```pycon
+>>> from pyargus.models import Incident
+>>> from pyargus.multivaluedict import MultiValueDict
+>>> tags = MultiValueDict([("host", "a.example.org"), ("host", "b.example.org")])
+>>> tags.add("location", "Milky way")
+>>> i = Incident(description="Two hosts affected", tags=tags)
+```
+
+Reading a multi-valued key through the ordinary `[]`/`get()` interface returns
+only the *last* value and emits a `DeprecationWarning`, because the other values
+are dropped silently. Use `getlist()` to retrieve them all:
+
+```pycon
+>>> tags.getlist("host")          # every value for the key
+['a.example.org', 'b.example.org']
+>>> tags["host"]                  # last value only; warns that values are dropped
+'b.example.org'
+>>> tags["location"]              # single-valued keys read normally, no warning
+'Milky way'
+>>> tags.lists()                  # all keys with all of their values
+[('host', ['a.example.org', 'b.example.org']), ('location', ['Milky way'])]
+>>> tags.allitems()               # every (key, value) pair, including repeats
+[('host', 'a.example.org'), ('host', 'b.example.org'), ('location', 'Milky way')]
+```
+
+Passing a plain `dict` as `tags` still works exactly as before, so existing code
+needs no changes.
 
 ### Stateless incidents
 

--- a/src/pyargus/__init__.py
+++ b/src/pyargus/__init__.py
@@ -2,5 +2,6 @@
 
 from pyargus.async_client import AsyncClient as AsyncClient
 from pyargus.client import Client as Client
+from pyargus.multivaluedict import MultiValueDict as MultiValueDict
 
 VERSION = "0.7.0"

--- a/src/pyargus/models.py
+++ b/src/pyargus/models.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from iso8601 import parse_date
 
+from pyargus.multivaluedict import MultiValueDict
+
 
 # STATELESS is a sentinel used as an `end_time` value to explicitly indicate that an
 # incident is in fact stateless. To the Argus API, this is represented by a null/None
@@ -49,7 +51,7 @@ class Incident:
     description: str = None
     level: int = None
     ticket_url: str = None
-    tags: dict = None
+    tags: MultiValueDict = None
     stateful: bool = None
     open: bool = None
     acked: bool = None
@@ -71,9 +73,8 @@ class Incident:
             kwargs["end_time"] = STATELESS
         kwargs["source"] = SourceSystem.from_json(kwargs["source"])
 
-        tags = [tag["tag"] for tag in kwargs["tags"]]
-        tags = dict(tag.split("=", maxsplit=1) for tag in tags)
-        kwargs["tags"] = tags
+        tag_pairs = (tag["tag"].split("=", maxsplit=1) for tag in kwargs["tags"])
+        kwargs["tags"] = MultiValueDict(tag_pairs)
 
         return cls(
             **{
@@ -100,8 +101,13 @@ class Incident:
                 if field == "source":
                     continue  # Source will be assigned by Argus when posted
                 if field == "tags":
-                    tags = ("{}={}".format(k, v) for k, v in value.items())
-                    value = [{"tag": t} for t in tags]
+                    tags = (
+                        value
+                        if isinstance(value, MultiValueDict)
+                        else MultiValueDict(value)
+                    )
+                    pairs = (f"{key}={v}" for key, v in tags.allitems())
+                    value = [{"tag": pair} for pair in pairs]
                 result[field] = value
         if "tags" not in result:  # API requires tags to be present, but it can be empty
             result["tags"] = []

--- a/src/pyargus/multivaluedict.py
+++ b/src/pyargus/multivaluedict.py
@@ -1,0 +1,251 @@
+"""A ``dict`` subclass that preserves multiple values per key.
+
+:class:`MultiValueDict` is intentionally free of any Argus-specific knowledge;
+incident tags are merely its first consumer.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Iterable
+from typing import Any
+
+# Sentinel distinguishing "no default supplied" from an explicit ``None`` default,
+# used by :meth:`MultiValueDict.pop`.
+_MISSING = object()
+
+
+class MultiValueDict(dict):
+    """A ``dict`` subclass that can hold more than one value per key.
+
+    Modelled on Django's ``django.utils.datastructures.MultiValueDict``. The
+    ``dict`` base always holds the *collapsed* view -- one value per key, the last
+    one assigned (last wins) -- so ``isinstance(d, dict)``, item access,
+    ``json.dumps(d)`` and ``dict(d)`` keep working exactly as for an ordinary
+    dict. A parallel store keeps every value for each key, in insertion order,
+    reachable through :meth:`getlist`, :meth:`lists`, :meth:`allitems`,
+    :meth:`add`, :meth:`setlist`, :meth:`remove` and :meth:`poplist`.
+
+    Unlike ``dict``, constructing from an iterable of ``(key, value)`` pairs with
+    repeated keys keeps *all* the values::
+
+        >>> d = MultiValueDict([("host", "a"), ("host", "b")])
+        >>> d.getlist("host")
+        ['a', 'b']
+        >>> dict(d)
+        {'host': 'b'}
+
+    Reading a multi-valued key through the single-value interface (``d[key]`` or
+    ``d.get(key)``) returns only the last value and emits a ``DeprecationWarning``,
+    because the other values are silently dropped. Use :meth:`getlist` instead.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if len(args) > 1:
+            raise TypeError(
+                f"MultiValueDict expected at most 1 argument, got {len(args)}"
+            )
+        super().__init__()
+        self._lists: dict[Any, list] = {}
+        if args:
+            self._merge(args[0], replace=False)
+        for key, value in kwargs.items():
+            self[key] = value
+
+    def _merge(self, source: Any, replace: bool) -> None:
+        """Fold ``source`` into this dict.
+
+        With ``replace=False`` a pairs iterable appends every value (preserving
+        repeated keys); with ``replace=True`` each pair assigns (last wins), to
+        mirror ``dict.update``. Mappings always assign per key, and another
+        ``MultiValueDict`` always contributes its full value lists.
+        """
+        if isinstance(source, MultiValueDict):
+            for key, values in source.lists():
+                self.setlist(key, values)
+        elif hasattr(source, "keys"):
+            for key in source.keys():
+                self[key] = source[key]
+        else:
+            for key, value in source:
+                if replace:
+                    self[key] = value
+                else:
+                    self.add(key, value)
+
+    # -- single-value (collapsed) interface -------------------------------------
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        # Replace semantics: assignment drops any prior values for the key.
+        super().__setitem__(key, value)
+        self._lists[key] = [value]
+
+    def __getitem__(self, key: Any) -> Any:
+        self._warn_if_lossy(key)
+        return super().__getitem__(key)
+
+    def get(self, key: Any, default: Any = None) -> Any:
+        self._warn_if_lossy(key)
+        return super().get(key, default)
+
+    def __delitem__(self, key: Any) -> None:
+        super().__delitem__(key)  # raises KeyError before we touch _lists
+        del self._lists[key]
+
+    def pop(self, key: Any, default: Any = _MISSING) -> Any:
+        if key in self:
+            value = super().__getitem__(key)  # collapsed last value, no warning
+            super().__delitem__(key)
+            del self._lists[key]
+            return value
+        if default is _MISSING:
+            raise KeyError(key)
+        return default
+
+    def popitem(self) -> tuple:
+        key, value = super().popitem()  # raises KeyError when empty
+        del self._lists[key]
+        return key, value
+
+    def setdefault(self, key: Any, default: Any = None) -> Any:
+        if key not in self:
+            self[key] = default
+        return super().__getitem__(key)  # collapsed last value, no warning
+
+    def clear(self) -> None:
+        super().clear()
+        self._lists.clear()
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        if len(args) > 1:
+            raise TypeError(f"update expected at most 1 argument, got {len(args)}")
+        if args:
+            self._merge(args[0], replace=True)
+        for key, value in kwargs.items():
+            self[key] = value
+
+    def _warn_if_lossy(self, key: Any) -> None:
+        values = self._lists.get(key)
+        if values is not None and len(values) > 1:
+            warnings.warn(
+                f"Key {key!r} has multiple values; single-value access returns "
+                f"only the last. Use getlist({key!r}) to get all of them.",
+                category=DeprecationWarning,
+                stacklevel=3,  # point at the caller of __getitem__/get
+            )
+
+    # -- multi-value interface --------------------------------------------------
+
+    def add(self, key: Any, value: Any) -> None:
+        """Append ``value`` to the values stored under ``key``."""
+        self._lists.setdefault(key, []).append(value)
+        super().__setitem__(key, value)  # collapsed view tracks the last value
+
+    def getlist(self, key: Any) -> list:
+        """Return a copy of every value stored under ``key`` (``[]`` if absent)."""
+        return list(self._lists.get(key, []))
+
+    def setlist(self, key: Any, values: Iterable) -> None:
+        """Replace all values under ``key``. An empty ``values`` removes the key."""
+        values = list(values)
+        if not values:
+            if key in self:
+                del self[key]
+            return
+        self._lists[key] = values
+        super().__setitem__(key, values[-1])
+
+    def lists(self) -> list:
+        """Return ``[(key, [values...]), ...]`` in insertion order, with copies."""
+        return [(key, list(values)) for key, values in self._lists.items()]
+
+    def allitems(self) -> list:
+        """Return every ``(key, value)`` pair, including repeats, in order.
+
+        Unlike :meth:`items` (which yields the collapsed view, one value per
+        key), this yields a separate pair for each stored value.
+        """
+        return [(key, value) for key, values in self._lists.items() for value in values]
+
+    def poplist(self, key: Any) -> list:
+        """Remove ``key`` and return all of its values (``KeyError`` if absent)."""
+        values = self._lists.pop(key)  # raises KeyError before we touch the base
+        super().__delitem__(key)
+        return values
+
+    def remove(self, key: Any, value: Any) -> None:
+        """Remove a single occurrence of ``value`` from ``key``.
+
+        Raises ``KeyError`` if the key is absent and ``ValueError`` if the value
+        is not present. If it was the key's last value, the key is removed.
+        """
+        values = self._lists[key]
+        values.remove(value)
+        if values:
+            super().__setitem__(key, values[-1])
+        else:
+            super().__delitem__(key)
+            del self._lists[key]
+
+    # -- copying, pickling, equality, repr --------------------------------------
+
+    def copy(self) -> MultiValueDict:
+        return MultiValueDict(self)
+
+    @classmethod
+    def fromkeys(cls, iterable: Iterable, value: Any = None) -> MultiValueDict:
+        # Like ``dict.fromkeys``, every key shares the same ``value`` object.
+        result = cls()
+        for key in iterable:
+            result[key] = value
+        return result
+
+    @classmethod
+    def _from_lists(cls, items: Iterable) -> MultiValueDict:
+        """Rebuild from the output of :meth:`lists`; used by ``__reduce_ex__``."""
+        result = cls()
+        for key, values in items:
+            result.setlist(key, values)
+        return result
+
+    def __reduce_ex__(self, protocol: int) -> tuple:
+        # Default dict pickling would rebuild only the collapsed base and drop the
+        # extra values, so reconstruct from the full lists instead.
+        return (self.__class__._from_lists, (self.lists(),))
+
+    def __or__(self, other: Any) -> MultiValueDict:
+        if not isinstance(other, dict):
+            return NotImplemented
+        result = self.copy()
+        result.update(other)
+        return result
+
+    def __ror__(self, other: Any) -> MultiValueDict:
+        if not isinstance(other, dict):
+            return NotImplemented
+        result = MultiValueDict(other)
+        result.update(self)
+        return result
+
+    def __ior__(self, other: Any) -> MultiValueDict:
+        self.update(other)
+        return self
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, MultiValueDict):
+            return self._lists == other._lists
+        return super().__eq__(other)  # compare the collapsed view to a plain dict
+
+    def __ne__(self, other: object) -> bool:
+        # dict supplies its own C-level __ne__ that ignores our __eq__, so it must
+        # be overridden explicitly (it is not auto-derived for a dict subclass).
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
+    # Defining __eq__ already resets __hash__ to None; spell it out for clarity.
+    __hash__ = None
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.allitems()!r})"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,62 @@
+from pyargus.models import Incident
+from pyargus.multivaluedict import MultiValueDict
+
+
+def make_api_incident(tags):
+    """A minimal Argus API incident payload carrying the given ``tags`` list."""
+    return {
+        "start_time": "2021-01-01T00:00:00+00:00",
+        "end_time": None,
+        "source": {"type": {"name": "test"}},
+        "tags": tags,
+    }
+
+
+class TestIncidentFromJson:
+    def test_when_tags_have_duplicate_keys_it_should_preserve_all_values(self):
+        data = make_api_incident([{"tag": "host=a"}, {"tag": "host=b"}])
+        incident = Incident.from_json(data)
+        assert isinstance(incident.tags, MultiValueDict)
+        assert incident.tags.getlist("host") == ["a", "b"]
+
+    def test_when_tag_value_contains_equals_it_should_split_only_once(self):
+        data = make_api_incident([{"tag": "url=https://example.org/?a=b"}])
+        incident = Incident.from_json(data)
+        assert incident.tags.getlist("url") == ["https://example.org/?a=b"]
+
+
+class TestIncidentToJson:
+    def test_when_tags_have_duplicate_values_it_should_emit_all(self):
+        incident = Incident(tags=MultiValueDict([("host", "a"), ("host", "b")]))
+        assert incident.to_json()["tags"] == [
+            {"tag": "host=a"},
+            {"tag": "host=b"},
+        ]
+
+    def test_when_tags_is_plain_dict_it_should_emit_list(self):
+        incident = Incident(tags={"host": "earth.example.org"})
+        assert incident.to_json()["tags"] == [{"tag": "host=earth.example.org"}]
+
+    def test_when_tags_have_several_keys_it_should_group_values_by_key(self):
+        incident = Incident(
+            tags=MultiValueDict([("host", "a"), ("loc", "oslo"), ("host", "b")])
+        )
+        assert incident.to_json()["tags"] == [
+            {"tag": "host=a"},
+            {"tag": "host=b"},
+            {"tag": "loc=oslo"},
+        ]
+
+    def test_when_tags_empty_it_should_emit_empty_list(self):
+        assert Incident(tags=MultiValueDict()).to_json()["tags"] == []
+
+    def test_when_tags_none_it_should_emit_empty_list(self):
+        assert Incident().to_json()["tags"] == []
+
+
+class TestIncidentTagRoundTrip:
+    def test_when_round_tripped_duplicate_keys_should_survive(self):
+        original = Incident(tags=MultiValueDict([("host", "a"), ("host", "b")]))
+        data = make_api_incident(original.to_json()["tags"])
+        restored = Incident.from_json(data)
+        assert restored.tags.getlist("host") == ["a", "b"]

--- a/tests/test_multivaluedict.py
+++ b/tests/test_multivaluedict.py
@@ -1,0 +1,413 @@
+import copy
+import json
+import pickle
+import warnings
+
+import pytest
+
+from pyargus.multivaluedict import MultiValueDict
+
+
+def assert_no_warning(func):
+    """Call ``func`` and fail if it emits a DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        return func()
+
+
+def assert_invariant(d):
+    """Assert the collapsed base and the ``_lists`` store agree.
+
+    This is the structural contract every mutation must preserve: the two stores
+    hold the same keys, no value list is empty, and the collapsed value for each
+    key is the last of its values.
+    """
+    assert set(d.keys()) == set(d._lists.keys())
+    for key, values in d._lists.items():
+        assert values, f"empty value list for {key!r}"
+        assert dict.__getitem__(d, key) == values[-1]
+
+
+class TestMultiValueDictConstruction:
+    def test_when_given_no_args_it_should_be_empty(self):
+        d = MultiValueDict()
+        assert len(d) == 0
+        assert d.lists() == []
+
+    def test_when_given_pairs_with_repeated_key_it_should_preserve_all_values(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert d.getlist("host") == ["a", "b"]
+
+    def test_when_given_pairs_with_repeated_key_collapsed_should_be_last(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert dict(d) == {"host": "b"}
+
+    def test_when_given_plain_dict_it_should_store_single_values(self):
+        d = MultiValueDict({"host": "a", "loc": "oslo"})
+        assert d.getlist("host") == ["a"]
+        assert d.getlist("loc") == ["oslo"]
+
+    def test_when_given_another_multivaluedict_it_should_copy_all_values(self):
+        source = MultiValueDict([("host", "a"), ("host", "b")])
+        d = MultiValueDict(source)
+        assert d.getlist("host") == ["a", "b"]
+
+    def test_when_copied_from_multivaluedict_it_should_be_independent(self):
+        source = MultiValueDict([("host", "a")])
+        d = MultiValueDict(source)
+        d.add("host", "b")
+        assert source.getlist("host") == ["a"]
+
+    def test_when_given_keyword_args_it_should_store_single_values(self):
+        d = MultiValueDict(host="a", loc="oslo")
+        assert d.getlist("host") == ["a"]
+        assert d.getlist("loc") == ["oslo"]
+
+    def test_when_given_mapping_and_kwargs_it_should_apply_kwargs_last(self):
+        d = MultiValueDict({"host": "a"}, host="b")
+        assert dict(d) == {"host": "b"}
+
+    def test_when_given_more_than_one_positional_arg_it_should_raise_typeerror(self):
+        with pytest.raises(TypeError):
+            MultiValueDict({"a": "1"}, {"b": "2"})
+
+    def test_when_given_generator_of_pairs_it_should_preserve_repeated_keys(self):
+        d = MultiValueDict(pair for pair in [("host", "a"), ("host", "b")])
+        assert d.getlist("host") == ["a", "b"]
+
+    def test_when_given_mapping_like_with_keys_it_should_treat_as_mapping(self):
+        # Anything exposing keys() is treated as a mapping (the dict.update rule),
+        # not as a pairs iterable.
+        class MappingLike:
+            def keys(self):
+                return ["host"]
+
+            def __getitem__(self, key):
+                return "a"
+
+        d = MultiValueDict(MappingLike())
+        assert d.getlist("host") == ["a"]
+
+
+class TestMultiValueDictCollapsedView:
+    def test_when_key_has_multiple_values_collapsed_value_should_be_last(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert assert_no_warning(lambda: dict(d)["host"]) == "b"
+
+    def test_when_iterated_it_should_yield_each_key_once(self):
+        d = MultiValueDict([("host", "a"), ("host", "b"), ("loc", "oslo")])
+        assert list(d) == ["host", "loc"]
+
+    def test_when_dumped_to_json_it_should_emit_collapsed_view(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert json.loads(json.dumps(d)) == {"host": "b"}
+
+    def test_when_len_called_it_should_count_distinct_keys(self):
+        d = MultiValueDict([("host", "a"), ("host", "b"), ("loc", "oslo")])
+        assert len(d) == 2
+
+    def test_when_empty_it_should_be_falsy(self):
+        assert not MultiValueDict()
+
+    def test_when_nonempty_it_should_be_truthy(self):
+        assert MultiValueDict([("host", "a")])
+
+    def test_when_str_called_it_should_show_expanded_structure(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert str(d) == repr(d)
+
+
+class TestMultiValueDictMultiAccessors:
+    def test_when_getlist_called_it_should_return_copy_of_values(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        values = d.getlist("host")
+        values.append("c")
+        assert d.getlist("host") == ["a", "b"]
+
+    def test_when_getlist_called_on_missing_key_it_should_return_empty_list(self):
+        assert MultiValueDict().getlist("nope") == []
+
+    def test_when_add_called_it_should_append_and_update_collapsed(self):
+        d = MultiValueDict([("host", "a")])
+        d.add("host", "b")
+        assert d.getlist("host") == ["a", "b"]
+        assert assert_no_warning(lambda: dict(d)["host"]) == "b"
+
+    def test_when_setlist_called_it_should_replace_all_values(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        d.setlist("host", ["x", "y", "z"])
+        assert d.getlist("host") == ["x", "y", "z"]
+
+    def test_when_setlist_called_on_absent_key_it_should_add_it(self):
+        d = MultiValueDict()
+        d.setlist("host", ["a", "b"])
+        assert d.getlist("host") == ["a", "b"]
+
+    def test_when_setlist_called_with_empty_it_should_remove_key(self):
+        d = MultiValueDict([("host", "a")])
+        d.setlist("host", [])
+        assert "host" not in d
+
+    def test_when_setlist_called_with_empty_on_absent_key_it_should_noop(self):
+        d = MultiValueDict()
+        d.setlist("host", [])
+        assert "host" not in d
+
+    def test_when_lists_called_it_should_return_pairs_of_key_and_value_list(self):
+        d = MultiValueDict([("host", "a"), ("host", "b"), ("loc", "oslo")])
+        assert d.lists() == [("host", ["a", "b"]), ("loc", ["oslo"])]
+
+    def test_when_returned_lists_mutated_it_should_not_affect_internal_state(self):
+        d = MultiValueDict([("host", "a")])
+        d.lists()[0][1].append("b")
+        assert d.getlist("host") == ["a"]
+
+    def test_when_allitems_called_it_should_return_every_pair_including_repeats(self):
+        d = MultiValueDict([("host", "a"), ("host", "b"), ("loc", "oslo")])
+        assert d.allitems() == [("host", "a"), ("host", "b"), ("loc", "oslo")]
+
+    def test_when_allitems_called_it_should_not_warn_on_multivalued_keys(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert assert_no_warning(d.allitems) == [("host", "a"), ("host", "b")]
+
+
+class TestMultiValueDictAssignmentAndDeletion:
+    def test_when_item_assigned_it_should_replace_prior_values(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        d["host"] = "x"
+        assert d.getlist("host") == ["x"]
+
+    def test_when_del_item_it_should_remove_key_and_all_values(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        del d["host"]
+        assert "host" not in d
+        assert d.getlist("host") == []
+
+    def test_when_pop_called_it_should_return_collapsed_scalar_and_remove_key(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert assert_no_warning(lambda: d.pop("host")) == "b"
+        assert "host" not in d
+
+    def test_when_pop_missing_with_default_it_should_return_default(self):
+        assert MultiValueDict().pop("nope", "fallback") == "fallback"
+
+    def test_when_pop_missing_without_default_it_should_raise_keyerror(self):
+        with pytest.raises(KeyError):
+            MultiValueDict().pop("nope")
+
+    def test_when_popitem_called_it_should_remove_a_key_entirely(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        key, value = d.popitem()
+        assert key == "host"
+        assert d.getlist("host") == []
+
+    def test_when_clear_called_it_should_empty_both_stores(self):
+        d = MultiValueDict([("host", "a"), ("loc", "oslo")])
+        d.clear()
+        assert len(d) == 0
+        assert d.lists() == []
+
+    def test_when_remove_called_it_should_drop_one_occurrence(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        d.remove("host", "a")
+        assert d.getlist("host") == ["b"]
+
+    def test_when_remove_last_occurrence_it_should_delete_key(self):
+        d = MultiValueDict([("host", "a")])
+        d.remove("host", "a")
+        assert "host" not in d
+
+    def test_when_remove_drops_last_value_collapsed_should_recompute(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        d.remove("host", "b")
+        assert assert_no_warning(lambda: dict(d)["host"]) == "a"
+
+    def test_when_remove_value_absent_it_should_raise_valueerror(self):
+        d = MultiValueDict([("host", "a")])
+        with pytest.raises(ValueError):
+            d.remove("host", "nope")
+
+    def test_when_poplist_called_it_should_return_all_values_and_remove_key(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert d.poplist("host") == ["a", "b"]
+        assert "host" not in d
+
+    def test_when_poplist_missing_it_should_raise_keyerror(self):
+        with pytest.raises(KeyError):
+            MultiValueDict().poplist("nope")
+
+    def test_when_setdefault_on_missing_it_should_set_and_return_default(self):
+        d = MultiValueDict()
+        assert d.setdefault("host", "a") == "a"
+        assert d.getlist("host") == ["a"]
+
+    def test_when_setdefault_on_present_it_should_return_existing_collapsed(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        assert assert_no_warning(lambda: d.setdefault("host", "x")) == "b"
+        assert d.getlist("host") == ["a", "b"]
+
+    def test_when_update_with_mapping_it_should_replace_and_stay_synced(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        d.update({"host": "x", "loc": "oslo"})
+        assert d.getlist("host") == ["x"]
+        assert d.getlist("loc") == ["oslo"]
+        assert_invariant(d)
+
+    def test_when_update_with_multivaluedict_it_should_carry_all_values(self):
+        d = MultiValueDict([("host", "a")])
+        d.update(MultiValueDict([("host", "x"), ("host", "y")]))
+        assert d.getlist("host") == ["x", "y"]
+        assert assert_no_warning(lambda: dict(d)["host"]) == "y"
+        assert_invariant(d)
+
+    def test_when_remove_missing_key_it_should_raise_keyerror(self):
+        with pytest.raises(KeyError):
+            MultiValueDict().remove("nope", "x")
+
+
+class TestMultiValueDictLossyReadWarning:
+    def test_when_key_has_multiple_values_getitem_should_warn(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        with pytest.warns(DeprecationWarning):
+            assert d["host"] == "b"
+
+    def test_when_key_has_single_value_getitem_should_not_warn(self):
+        d = MultiValueDict([("loc", "oslo")])
+        assert assert_no_warning(lambda: d["loc"]) == "oslo"
+
+    def test_when_key_has_multiple_values_get_should_warn(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        with pytest.warns(DeprecationWarning):
+            assert d.get("host") == "b"
+
+    def test_when_key_has_single_value_get_should_not_warn(self):
+        d = MultiValueDict([("loc", "oslo")])
+        assert assert_no_warning(lambda: d.get("loc")) == "oslo"
+
+    def test_when_get_with_default_on_multivalued_key_it_should_warn_and_return_last(
+        self,
+    ):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        with pytest.warns(DeprecationWarning):
+            assert d.get("host", "fallback") == "b"
+
+    def test_when_get_with_default_on_missing_key_it_should_return_default(self):
+        d = MultiValueDict([("host", "a")])
+        assert assert_no_warning(lambda: d.get("nope", "fallback")) == "fallback"
+
+    def test_when_lossy_read_warning_should_point_at_caller(self):
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        with pytest.warns(DeprecationWarning) as record:
+            d["host"]
+        assert record[0].filename == __file__
+
+
+class TestMultiValueDictEquality:
+    def test_when_same_multivalues_two_instances_should_be_equal(self):
+        a = MultiValueDict([("host", "a"), ("host", "b")])
+        b = MultiValueDict([("host", "a"), ("host", "b")])
+        assert a == b
+
+    def test_when_collapsed_equal_but_multivalues_differ_should_not_be_equal(self):
+        a = MultiValueDict([("host", "a"), ("host", "b")])
+        b = MultiValueDict([("host", "b")])
+        assert a != b
+        assert not (a == b)
+
+    def test_when_compared_to_equal_plain_dict_it_should_equal_collapsed_view(self):
+        a = MultiValueDict([("host", "a"), ("host", "b")])
+        assert a == {"host": "b"}
+        assert not (a != {"host": "b"})
+
+    def test_when_compared_to_unequal_object_it_should_not_be_equal(self):
+        assert MultiValueDict([("host", "a")]) != "not a dict"
+
+    def test_when_compared_to_equal_plain_dict_subclass_it_should_be_equal(self):
+        class CustomDict(dict):
+            pass
+
+        a = MultiValueDict([("host", "a"), ("host", "b")])
+        assert a == CustomDict(host="b")
+
+
+class TestMultiValueDictCopyPickleReprUnion:
+    def test_when_copy_method_called_it_should_return_independent_multivaluedict(self):
+        src = MultiValueDict([("host", "a"), ("host", "b")])
+        clone = src.copy()
+        assert isinstance(clone, MultiValueDict)
+        assert clone.getlist("host") == ["a", "b"]
+        clone.add("host", "c")
+        assert src.getlist("host") == ["a", "b"]
+
+    def test_when_copy_copy_called_it_should_preserve_multivalues(self):
+        src = MultiValueDict([("host", "a"), ("host", "b")])
+        assert copy.copy(src).getlist("host") == ["a", "b"]
+
+    def test_when_deepcopy_called_it_should_preserve_multivalues_and_be_independent(
+        self,
+    ):
+        src = MultiValueDict([("host", "a"), ("host", "b")])
+        clone = copy.deepcopy(src)
+        assert clone.getlist("host") == ["a", "b"]
+        clone.add("host", "c")
+        assert src.getlist("host") == ["a", "b"]
+
+    def test_when_pickled_and_unpickled_it_should_preserve_multivalues(self):
+        src = MultiValueDict([("host", "a"), ("host", "b")])
+        restored = pickle.loads(pickle.dumps(src))
+        assert isinstance(restored, MultiValueDict)
+        assert restored.getlist("host") == ["a", "b"]
+
+    def test_when_repr_called_it_should_round_trip_via_constructor(self):
+        src = MultiValueDict([("host", "a"), ("host", "b"), ("loc", "oslo")])
+        assert eval(repr(src)) == src
+
+    def test_when_union_operator_used_it_should_return_multivaluedict(self):
+        result = MultiValueDict([("host", "a")]) | {"host": "b", "loc": "oslo"}
+        assert isinstance(result, MultiValueDict)
+        assert result.getlist("host") == ["b"]
+        assert result.getlist("loc") == ["oslo"]
+
+    def test_when_reverse_union_with_plain_mapping_it_should_return_multivaluedict(
+        self,
+    ):
+        class Mapping(dict):
+            pass
+
+        result = MultiValueDict([("host", "b")]).__ror__(Mapping(host="a"))
+        assert isinstance(result, MultiValueDict)
+        assert result.getlist("host") == ["b"]
+
+    def test_when_inplace_union_used_with_multivaluedict_it_should_carry_values(self):
+        d = MultiValueDict([("a", "1")])
+        d |= MultiValueDict([("a", "2"), ("a", "3")])
+        assert d.getlist("a") == ["2", "3"]
+
+    def test_when_fromkeys_used_it_should_build_multivaluedict(self):
+        d = MultiValueDict.fromkeys(["a", "b"], 0)
+        assert isinstance(d, MultiValueDict)
+        assert dict(d) == {"a": 0, "b": 0}
+
+
+class TestMultiValueDictInvariant:
+    def test_when_mutated_through_a_sequence_it_should_stay_consistent(self):
+        # Drive the structure through every mutating operation and assert the
+        # collapsed base never drifts from the _lists store along the way.
+        d = MultiValueDict([("host", "a"), ("host", "b")])
+        operations = [
+            lambda: d.add("host", "c"),
+            lambda: d.add("loc", "oslo"),
+            lambda: d.__setitem__("host", "z"),
+            lambda: d.setlist("host", ["1", "2", "3"]),
+            lambda: d.remove("host", "2"),
+            lambda: d.update(MultiValueDict([("host", "x"), ("host", "y")])),
+            lambda: d.update({"loc": "bergen"}),
+            lambda: d.__ior__(MultiValueDict([("env", "prod"), ("env", "test")])),
+            lambda: d.poplist("host"),
+            lambda: d.pop("loc"),
+            lambda: d.setdefault("new", "val"),
+            lambda: d.popitem(),
+        ]
+        for operation in operations:
+            operation()
+            assert_invariant(d)


### PR DESCRIPTION
## Scope and purpose

Closes #52.

The Argus API represents an incident's tags as a list and allows the same tag key to appear more than once (for example two different `host` values). pyargus modelled `Incident.tags` as a plain `dict`, so repeated keys were silently dropped when reading incidents and could not be expressed when posting them. This change makes pyargus faithfully round-trip multi-valued tags.

`Incident.tags` is now a [`MultiValueDict`](https://github.com/Uninett/pyargus/blob/d0e76cad6a671cfd965cea5807c010a977ade353/src/pyargus/multivaluedict.py#L18) — a `dict` subclass that keeps every value per key while still behaving like an ordinary dictionary for the common single-value case. Existing code that treats `tags` as a `{key: value}` dict keeps working unchanged (the live integration tests still post `tags={"host": ...}` against a real Argus server and pass); multi-aware callers use `getlist`/`add`/`lists`/`remove`/`poplist`. Reading a key that holds several values through the single-value interface returns the last value and emits a `DeprecationWarning`, mirroring how Django's `QueryDict` exposes a collapsed view.

### This pull request
* changes the library's public API — `Incident.tags` is now a `MultiValueDict` rather than a plain `dict`. The change is backwards compatible (it subclasses `dict`) and introduces no new runtime dependency.

## Contributor Checklist

* [x] Added an entry to `CHANGELOG.md`
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://pre-commit.com/)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
