### PR TITLE
Add source-system heartbeat support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added helper functions for restarting an incident.
+- Added `Client.send_heartbeat()` and `AsyncClient.send_heartbeat()` for sending a source system heartbeat to Argus via the `sources/heartbeat/` endpoint.
+- Added `Client.supports_heartbeat()` and `AsyncClient.supports_heartbeat()` for detecting whether the connected Argus server provides the heartbeat endpoint.
 
 ### Changed
 - Made default timestamps timezone-aware.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,50 @@ c = Client(api_root_url="https://argus.example.org/api/v2", token=tokenobj.token
 # secrets file so that it is not lost on program exit
 ```
 
+### Send a heartbeat
+
+A source system with no incidents to report looks exactly like one that has
+crashed. Every glue service should therefore send a *heartbeat* on a regular
+schedule to prove it is still alive. A heartbeat updates the source system's
+`last_seen` timestamp on the server without posting an incident, so Argus can
+tell a healthy-but-quiet source apart from a dead one.
+
+```python
+c.send_heartbeat()
+```
+
+The method returns `None` on success. On failure it raises an exception from
+`simple_rest_client`, the HTTP client library that pyargus is built on; these
+exceptions are defined in its `simple_rest_client.exceptions` module (for
+example, `AuthError` for a `401` or `403` response).
+
+#### Detecting whether the server supports heartbeats
+
+The heartbeat endpoint requires an Argus server new enough to provide it.
+Older servers don't fail cleanly on a `POST` — they reject it with a `403` that
+is indistinguishable from an authentication error — so don't infer support from
+the `send_heartbeat()` outcome. Instead, probe up front with
+`supports_heartbeat()`, which issues a `GET` and returns whether the endpoint is
+present:
+
+```python
+if c.supports_heartbeat():
+    c.send_heartbeat()
+```
+
+A long-running glue service can check once at startup and decide whether to
+bother sending heartbeats at all:
+
+```python
+c = Client(api_root_url="https://argus.example.org/api/v2", token="foobar")
+heartbeats_enabled = c.supports_heartbeat()
+while running:
+    do_work()
+    if heartbeats_enabled:
+        c.send_heartbeat()
+    sleep(interval)
+```
+
 ## Async usage
 
 An `AsyncClient` is available for use in asyncio-based applications. It mirrors
@@ -187,6 +231,9 @@ Incident(pk=4, ...)
 ... )
 >>> await c.post_incident(i)
 Incident(pk=8, ...)
+>>> if await c.supports_heartbeat():
+...     await c.send_heartbeat()
+...
 ```
 
 ## BUGS

--- a/src/pyargus/api.py
+++ b/src/pyargus/api.py
@@ -61,6 +61,10 @@ class SourceSystemResource(Resource):
         # The Argus source system endpoints are served under the incident app,
         # hence the "incidents/" URL prefix.
         "heartbeat": {"method": "POST", "url": "incidents/sources/heartbeat/"},
+        # A GET against the same URL is used only to probe for endpoint support:
+        # the endpoint accepts POST only, so it answers non-404 (405 today) when
+        # present and 404 when absent on older servers. See supports_heartbeat().
+        "heartbeat_probe": {"method": "GET", "url": "incidents/sources/heartbeat/"},
     }
 
 

--- a/src/pyargus/api.py
+++ b/src/pyargus/api.py
@@ -22,6 +22,7 @@ def connect(api_root_url: str, token: str, timeout: float = 2.0) -> API:
     argusapi.add_resource(
         resource_name="acknowledgements", resource_class=IncidentAcknowledgementResource
     )
+    argusapi.add_resource(resource_name="sources", resource_class=SourceSystemResource)
     argusapi.add_resource(resource_name="tokens", resource_class=ExpiringTokenResource)
     return argusapi
 
@@ -52,6 +53,14 @@ class IncidentAcknowledgementResource(Resource):
         "list": {"method": "GET", "url": "incidents/{}/acks"},
         "create": {"method": "POST", "url": "incidents/{}/acks"},
         "retrieve": {"method": "GET", "url": "incidents/{}/acks/{}"},
+    }
+
+
+class SourceSystemResource(Resource):
+    actions = {
+        # The Argus source system endpoints are served under the incident app,
+        # hence the "incidents/" URL prefix.
+        "heartbeat": {"method": "POST", "url": "incidents/sources/heartbeat/"},
     }
 
 

--- a/src/pyargus/async_api.py
+++ b/src/pyargus/async_api.py
@@ -8,6 +8,7 @@ from .api import (
     IncidentAcknowledgementResource,
     IncidentEventResource,
     IncidentResource,
+    SourceSystemResource,
 )
 
 
@@ -35,6 +36,9 @@ def async_connect(api_root_url: str, token: str, timeout: float = 2.0) -> API:
         resource_class=AsyncIncidentAcknowledgementResource,
     )
     argusapi.add_resource(
+        resource_name="sources", resource_class=AsyncSourceSystemResource
+    )
+    argusapi.add_resource(
         resource_name="tokens", resource_class=AsyncExpiringTokenResource
     )
     return argusapi
@@ -50,6 +54,10 @@ class AsyncIncidentEventResource(AsyncResource):
 
 class AsyncIncidentAcknowledgementResource(AsyncResource):
     actions = IncidentAcknowledgementResource.actions
+
+
+class AsyncSourceSystemResource(AsyncResource):
+    actions = SourceSystemResource.actions
 
 
 class AsyncExpiringTokenResource(AsyncResource):

--- a/src/pyargus/async_client.py
+++ b/src/pyargus/async_client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import AsyncIterator, Callable, List, Optional, Tuple
 
+from simple_rest_client.exceptions import AuthError, ClientError, NotFoundError
+
 from . import async_api, models
 from .client import IncidentType, extract_params, has_next_page, is_paginated_response
 from .time import now as utcnow
@@ -148,6 +150,28 @@ class AsyncClient:
         response = await self.api.events.create(incident_pk, body=body)
         return models.Event.from_json(response.body)
 
+    async def supports_heartbeat(self) -> bool:
+        """Detects whether the connected Argus server provides the heartbeat endpoint.
+
+        Probes the endpoint with a GET request: a server that has it answers with
+        a non-404 status (currently 405, as the endpoint only accepts POST), while
+        a server too old to provide it answers with 404. Use this to decide whether
+        to call `send_heartbeat()` at all.
+
+        :returns: True if the server provides the heartbeat endpoint, else False.
+        :raises AuthError: if the token is missing or invalid (HTTP 401); support
+            cannot be determined without authenticating.
+        """
+        try:
+            await self.api.sources.heartbeat_probe()
+            return True  # 2xx: the endpoint exists
+        except NotFoundError:
+            return False  # 404: the endpoint is absent (older Argus)
+        except AuthError:
+            raise  # 401: cannot determine support without valid credentials
+        except ClientError:
+            return True  # e.g. 405: the endpoint exists but GET is not allowed
+
     async def send_heartbeat(self) -> None:
         """Sends a heartbeat to Argus to signal that this source system is alive.
 
@@ -161,7 +185,9 @@ class AsyncClient:
         underlying HTTP library (for example `AuthError` if the token does not
         belong to a source system). Note that an Argus server too old to provide
         this endpoint typically answers with a 403 as well, which is
-        indistinguishable from a genuine authentication failure.
+        indistinguishable from a genuine authentication failure; use
+        `supports_heartbeat()` to detect endpoint support up front rather than
+        inferring it from this method's failure.
         """
         await self.api.sources.heartbeat()
 

--- a/src/pyargus/async_client.py
+++ b/src/pyargus/async_client.py
@@ -148,6 +148,23 @@ class AsyncClient:
         response = await self.api.events.create(incident_pk, body=body)
         return models.Event.from_json(response.body)
 
+    async def send_heartbeat(self) -> None:
+        """Sends a heartbeat to Argus to signal that this source system is alive.
+
+        This updates the source system's `last_seen` timestamp server-side without
+        posting an incident. Every glue service should send heartbeats on a regular
+        schedule to prove it is alive: a source with nothing to report looks exactly
+        like a source that has died, and a steady heartbeat is what lets Argus tell
+        the two apart.
+
+        On a non-2xx response it raises an exception from `simple_rest_client`, the
+        underlying HTTP library (for example `AuthError` if the token does not
+        belong to a source system). Note that an Argus server too old to provide
+        this endpoint typically answers with a 403 as well, which is
+        indistinguishable from a genuine authentication failure.
+        """
+        await self.api.sources.heartbeat()
+
     async def refresh_token(self) -> models.ExpiringToken:
         """Post w/o body to get a new token and its expiration timestamp
 

--- a/src/pyargus/client.py
+++ b/src/pyargus/client.py
@@ -153,6 +153,23 @@ class Client:
         response = self.api.events.create(incident_pk, body=body)
         return models.Event.from_json(response.body)
 
+    def send_heartbeat(self) -> None:
+        """Sends a heartbeat to Argus to signal that this source system is alive.
+
+        This updates the source system's `last_seen` timestamp server-side without
+        posting an incident. Every glue service should send heartbeats on a regular
+        schedule to prove it is alive: a source with nothing to report looks exactly
+        like a source that has died, and a steady heartbeat is what lets Argus tell
+        the two apart.
+
+        On a non-2xx response it raises an exception from `simple_rest_client`, the
+        underlying HTTP library (for example `AuthError` if the token does not
+        belong to a source system). Note that an Argus server too old to provide
+        this endpoint typically answers with a 403 as well, which is
+        indistinguishable from a genuine authentication failure.
+        """
+        self.api.sources.heartbeat()
+
     def refresh_token(self) -> models.ExpiringToken:
         """Post w/o body to get a new token and its expiration timestamp
 

--- a/src/pyargus/client.py
+++ b/src/pyargus/client.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Callable, Iterator, List, Optional, Tuple, TypeVar
 from urllib.parse import parse_qs, urlparse
 
+from simple_rest_client.exceptions import AuthError, ClientError, NotFoundError
 from simple_rest_client.models import Response
 
 from . import api, models
@@ -153,6 +154,28 @@ class Client:
         response = self.api.events.create(incident_pk, body=body)
         return models.Event.from_json(response.body)
 
+    def supports_heartbeat(self) -> bool:
+        """Detects whether the connected Argus server provides the heartbeat endpoint.
+
+        Probes the endpoint with a GET request: a server that has it answers with
+        a non-404 status (currently 405, as the endpoint only accepts POST), while
+        a server too old to provide it answers with 404. Use this to decide whether
+        to call `send_heartbeat()` at all.
+
+        :returns: True if the server provides the heartbeat endpoint, else False.
+        :raises AuthError: if the token is missing or invalid (HTTP 401); support
+            cannot be determined without authenticating.
+        """
+        try:
+            self.api.sources.heartbeat_probe()
+            return True  # 2xx: the endpoint exists
+        except NotFoundError:
+            return False  # 404: the endpoint is absent (older Argus)
+        except AuthError:
+            raise  # 401: cannot determine support without valid credentials
+        except ClientError:
+            return True  # e.g. 405: the endpoint exists but GET is not allowed
+
     def send_heartbeat(self) -> None:
         """Sends a heartbeat to Argus to signal that this source system is alive.
 
@@ -166,7 +189,9 @@ class Client:
         underlying HTTP library (for example `AuthError` if the token does not
         belong to a source system). Note that an Argus server too old to provide
         this endpoint typically answers with a 403 as well, which is
-        indistinguishable from a genuine authentication failure.
+        indistinguishable from a genuine authentication failure; use
+        `supports_heartbeat()` to detect endpoint support up front rather than
+        inferring it from this method's failure.
         """
         self.api.sources.heartbeat()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,3 +12,10 @@ def test_api_client_with_bad_args_should_fail():
     client = api.connect("random", "token")
     with pytest.raises(Exception):
         client.incidents.list_open_unacked()
+
+
+def test_connect_should_expose_source_heartbeat_action():
+    client = api.connect("random", "token")
+    action = client.sources.actions["heartbeat"]
+    assert action["method"] == "POST"
+    assert action["url"] == "incidents/sources/heartbeat/"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,3 +19,10 @@ def test_connect_should_expose_source_heartbeat_action():
     action = client.sources.actions["heartbeat"]
     assert action["method"] == "POST"
     assert action["url"] == "incidents/sources/heartbeat/"
+
+
+def test_connect_should_expose_source_heartbeat_probe_action():
+    client = api.connect("random", "token")
+    action = client.sources.actions["heartbeat_probe"]
+    assert action["method"] == "GET"
+    assert action["url"] == "incidents/sources/heartbeat/"

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -20,3 +20,4 @@ async def test_async_api_client_with_bad_args_should_fail():
 def test_async_connect_should_expose_source_heartbeat_action():
     client = async_api.async_connect("random", "token")
     assert "heartbeat" in client.sources.actions
+    assert "heartbeat_probe" in client.sources.actions

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -15,3 +15,8 @@ async def test_async_api_client_with_bad_args_should_fail():
     client = async_api.async_connect("random", "token")
     with pytest.raises(Exception):
         await client.incidents.list_open_unacked()
+
+
+def test_async_connect_should_expose_source_heartbeat_action():
+    client = async_api.async_connect("random", "token")
+    assert "heartbeat" in client.sources.actions

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -2,7 +2,7 @@ from collections.abc import AsyncIterable
 from unittest.mock import AsyncMock
 
 import pytest
-from simple_rest_client.exceptions import AuthError
+from simple_rest_client.exceptions import AuthError, ClientError, NotFoundError
 
 from pyargus.async_client import AsyncClient
 from pyargus.models import Incident
@@ -48,6 +48,21 @@ class TestAsyncApiIntegration:
     ):
         assert await async_api_client.send_heartbeat() is None
 
+    # supports_heartbeat() returns False against Argus <= 2.9.1 (no endpoint,
+    # GET -> 404). Asserting the supporting-server result (True) keeps this test
+    # symmetric with the send_heartbeat xfail above: it is expected to fail until
+    # the suite runs against an Argus that provides sources/heartbeat/, at which
+    # point (being strict) it flips to a failure prompting removal of the marker.
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Argus <= 2.9.1 has no sources/heartbeat/ endpoint; detection is False",
+    )
+    @pytest.mark.asyncio
+    async def test_when_server_provides_endpoint_supports_heartbeat_should_be_true(
+        self, async_api_client
+    ):
+        assert await async_api_client.supports_heartbeat() is True
+
 
 class TestAsyncSendHeartbeat:
     @pytest.mark.asyncio
@@ -57,6 +72,37 @@ class TestAsyncSendHeartbeat:
         result = await client.send_heartbeat()
         client.api.sources.heartbeat.assert_awaited_once_with()
         assert result is None
+
+
+class TestAsyncSupportsHeartbeat:
+    @pytest.mark.asyncio
+    async def test_when_server_answers_2xx_it_should_return_true(self):
+        client = self._client_with_probe(return_value=object())
+        assert await client.supports_heartbeat() is True
+        client.api.sources.heartbeat_probe.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_when_server_answers_404_it_should_return_false(self):
+        client = self._client_with_probe(side_effect=NotFoundError("not found", None))
+        assert await client.supports_heartbeat() is False
+
+    @pytest.mark.asyncio
+    async def test_when_get_is_not_allowed_it_should_return_true(self):
+        client = self._client_with_probe(side_effect=ClientError("405", None))
+        assert await client.supports_heartbeat() is True
+
+    @pytest.mark.asyncio
+    async def test_when_credentials_are_invalid_it_should_raise(self):
+        client = self._client_with_probe(side_effect=AuthError("401", None))
+        with pytest.raises(AuthError):
+            await client.supports_heartbeat()
+
+    def _client_with_probe(self, side_effect=None, return_value=None):
+        client = AsyncClient("https://argus.example.org/api/v2", "token")
+        client.api.sources.heartbeat_probe = AsyncMock(
+            side_effect=side_effect, return_value=return_value
+        )
+        return client
 
 
 @pytest.fixture

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,6 +1,8 @@
 from collections.abc import AsyncIterable
+from unittest.mock import AsyncMock
 
 import pytest
+from simple_rest_client.exceptions import AuthError
 
 from pyargus.async_client import AsyncClient
 from pyargus.models import Incident
@@ -28,6 +30,33 @@ class TestAsyncApiIntegration:
         assert isinstance(result, Incident)
         assert result.description == post.description
         assert result.pk
+
+    # The heartbeat endpoint is unreleased as of Argus 2.9.1, the newest version
+    # available for integration testing. A server without the endpoint answers
+    # with 403, which pyargus surfaces as AuthError, so this test is expected to
+    # fail until the suite runs against an Argus release that provides
+    # sources/heartbeat/. Being strict, it will start failing (as XPASS) once
+    # that happens -- at which point this marker should be removed.
+    @pytest.mark.xfail(
+        raises=AuthError,
+        strict=True,
+        reason="Argus <= 2.9.1 has no sources/heartbeat/ endpoint; returns 403",
+    )
+    @pytest.mark.asyncio
+    async def test_when_authenticated_as_source_send_heartbeat_should_not_raise(
+        self, async_api_client
+    ):
+        assert await async_api_client.send_heartbeat() is None
+
+
+class TestAsyncSendHeartbeat:
+    @pytest.mark.asyncio
+    async def test_when_called_it_should_post_to_the_sources_heartbeat_action(self):
+        client = AsyncClient("https://argus.example.org/api/v2", "token")
+        client.api.sources.heartbeat = AsyncMock()
+        result = await client.send_heartbeat()
+        client.api.sources.heartbeat.assert_awaited_once_with()
+        assert result is None
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 from unittest.mock import MagicMock
 
 import pytest
-from simple_rest_client.exceptions import AuthError
+from simple_rest_client.exceptions import AuthError, ClientError, NotFoundError
 
 from pyargus.client import Client
 from pyargus.models import Incident
@@ -43,6 +43,20 @@ class TestApiIntegration:
     ):
         assert api_client.send_heartbeat() is None
 
+    # supports_heartbeat() returns False against Argus <= 2.9.1 (no endpoint,
+    # GET -> 404). Asserting the supporting-server result (True) keeps this test
+    # symmetric with the send_heartbeat xfail above: it is expected to fail until
+    # the suite runs against an Argus that provides sources/heartbeat/, at which
+    # point (being strict) it flips to a failure prompting removal of the marker.
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Argus <= 2.9.1 has no sources/heartbeat/ endpoint; detection is False",
+    )
+    def test_when_server_provides_endpoint_supports_heartbeat_should_be_true(
+        self, api_client
+    ):
+        assert api_client.supports_heartbeat() is True
+
 
 class TestSendHeartbeat:
     def test_when_called_it_should_post_to_the_sources_heartbeat_action(self):
@@ -51,6 +65,33 @@ class TestSendHeartbeat:
         result = client.send_heartbeat()
         client.api.sources.heartbeat.assert_called_once_with()
         assert result is None
+
+
+class TestSupportsHeartbeat:
+    def test_when_server_answers_2xx_it_should_return_true(self):
+        client = self._client_with_probe(return_value=object())
+        assert client.supports_heartbeat() is True
+        client.api.sources.heartbeat_probe.assert_called_once_with()
+
+    def test_when_server_answers_404_it_should_return_false(self):
+        client = self._client_with_probe(side_effect=NotFoundError("not found", None))
+        assert client.supports_heartbeat() is False
+
+    def test_when_get_is_not_allowed_it_should_return_true(self):
+        client = self._client_with_probe(side_effect=ClientError("405", None))
+        assert client.supports_heartbeat() is True
+
+    def test_when_credentials_are_invalid_it_should_raise(self):
+        client = self._client_with_probe(side_effect=AuthError("401", None))
+        with pytest.raises(AuthError):
+            client.supports_heartbeat()
+
+    def _client_with_probe(self, side_effect=None, return_value=None):
+        client = Client("https://argus.example.org/api/v2", "token")
+        client.api.sources.heartbeat_probe = MagicMock(
+            side_effect=side_effect, return_value=return_value
+        )
+        return client
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 from collections.abc import Iterable
+from unittest.mock import MagicMock
 
 import pytest
+from simple_rest_client.exceptions import AuthError
 
 from pyargus.client import Client
 from pyargus.models import Incident
@@ -24,6 +26,31 @@ class TestApiIntegration:
         assert isinstance(result, Incident)
         assert result.description == post.description
         assert result.pk
+
+    # The heartbeat endpoint is unreleased as of Argus 2.9.1, the newest version
+    # available for integration testing. A server without the endpoint answers
+    # with 403, which pyargus surfaces as AuthError, so this test is expected to
+    # fail until the suite runs against an Argus release that provides
+    # sources/heartbeat/. Being strict, it will start failing (as XPASS) once
+    # that happens -- at which point this marker should be removed.
+    @pytest.mark.xfail(
+        raises=AuthError,
+        strict=True,
+        reason="Argus <= 2.9.1 has no sources/heartbeat/ endpoint; returns 403",
+    )
+    def test_when_authenticated_as_source_send_heartbeat_should_not_raise(
+        self, api_client
+    ):
+        assert api_client.send_heartbeat() is None
+
+
+class TestSendHeartbeat:
+    def test_when_called_it_should_post_to_the_sources_heartbeat_action(self):
+        client = Client("https://argus.example.org/api/v2", "token")
+        client.api.sources.heartbeat = MagicMock()
+        result = client.send_heartbeat()
+        client.api.sources.heartbeat.assert_called_once_with()
+        assert result is None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Scope and purpose

Fixes #58.

Argus [gained a dedicated source-system heartbeat endpoint](https://github.com/Uninett/Argus/pull/1939) that lets a source prove it is still alive by updating its `last_seen` timestamp without posting an incident. A source with nothing to report is otherwise indistinguishable from a dead glue service, so glue services need a way to send these heartbeats — which this client did not previously support.

This adds two public methods to both `Client` and `AsyncClient`: [`send_heartbeat()`](https://github.com/Uninett/pyargus/blob/6a98b5182299bf41b447d5949242e40e06990747/src/pyargus/client.py#L179) posts a heartbeat, and [`supports_heartbeat()`](https://github.com/Uninett/pyargus/blob/6a98b5182299bf41b447d5949242e40e06990747/src/pyargus/client.py#L157) reports whether the connected server provides the endpoint. The detection helper exists because the endpoint is unreleased as of Argus 2.9.1, and an Argus without it rejects the heartbeat POST with a `403` that cannot be told apart from a genuine authentication failure (see Uninett/Argus#2002); probing with a `GET` gives an unambiguous 404-vs-non-404 answer, so a caller can decide up front whether to send heartbeats at all. The README documents the recommended probe-once-then-send pattern.

Because no released Argus provides the endpoint yet, the live integration tests are marked strict `xfail`; they will flip to failures — prompting their removal — once the test suite runs against a supporting Argus.

### This pull request
* adds two new public methods (`send_heartbeat`, `supports_heartbeat`) to `Client` and `AsyncClient` — the change is additive and backwards-compatible

## Contributor Checklist

* [x] Added an entry to `CHANGELOG.md`
* [x] Added/amended tests for new/changed code
* [x] Linted/formatted the code with ruff, easiest by using [pre-commit](https://pre-commit.com/)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
